### PR TITLE
Feature/Ability to define static fields in the logger document root

### DIFF
--- a/.circleci/gemspecs/latest
+++ b/.circleci/gemspecs/latest
@@ -26,8 +26,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 13.1'
   spec.add_development_dependency 'reek', '~> 6.3'
   spec.add_development_dependency 'rspec', '~> 3.13'
-  spec.add_development_dependency 'rubocop', '~> 1.61'
-  spec.add_development_dependency 'rubocop-performance', '~> 1.20', '>= 1.20.2'
-  spec.add_development_dependency 'rubocop-rspec', '~> 2.27', '>= 2.27.1'
+  spec.add_development_dependency 'rubocop', '~> 1.62', '>= 1.62.1'
+  spec.add_development_dependency 'rubocop-performance', '~> 1.21'
+  spec.add_development_dependency 'rubocop-rspec', '= 2.27.1'
   spec.add_development_dependency 'simplecov', '~> 0.22.0'
 end

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -9,7 +9,7 @@ checks:
 plugins:
   rubocop:
     enabled: true
-    channel: rubocop-1-61
+    channel: rubocop-1-62
     config:
       file: .circleci/linter_configs/.rubocop.yml
 

--- a/README.md
+++ b/README.md
@@ -73,11 +73,12 @@ To start working with this gem, you must configure it first as in the example be
 require 'on_strum/logs'
 
 OnStrum::Logs.configure do |config|
-  # Required parameter. Current service name.
-  config.service_name = 'My Great Application'
-
-  # Required parameter. Current service version.
-  config.service_version = '1.42.0'
+  # Optional parameter. Ability to define static fields in the logger document root.
+  # It is equal to empty hash by default.
+  config.root_fields = {
+    service_name: 'My Great Application',
+    service_version: '1.42.0'
+  }
 
   # Optional parameter. The colorized structured log in STDOUT. It could be useful
   # for debug mode.
@@ -211,8 +212,10 @@ For view detailed colorized logs you can use configuration option `detailed_form
 require 'on_strum/logs'
 
 OnStrum::Logs.configure do |config|
-  config.service_name = 'My Great Application'
-  config.service_version = '1.42.0'
+  config.root_fields = {
+    service_name: 'My Great Application',
+    service_version: '1.42.0'
+  }
   config.detailed_formatter = true
 end
 

--- a/lib/on_strum/logs.rb
+++ b/lib/on_strum/logs.rb
@@ -9,10 +9,7 @@ module OnStrum
         @configuration ||= begin
           return unless block
 
-          configuration = OnStrum::Logs::Configuration.new(&block)
-          raise OnStrum::Logs::Error::Configuration, OnStrum::Logs::Configuration::INCOMPLETE_CONFIG unless configuration.complete?
-
-          configuration
+          OnStrum::Logs::Configuration.new(&block)
         end
       end
 

--- a/lib/on_strum/logs/configuration.rb
+++ b/lib/on_strum/logs/configuration.rb
@@ -3,11 +3,9 @@
 module OnStrum
   module Logs
     class Configuration
-      INCOMPLETE_CONFIG = 'service_name, service_version are required parameters'
       SETTERS = %i[
         custom_formatter
-        service_name
-        service_version
+        root_fields
         field_name_level
         field_name_time
         field_name_message
@@ -32,19 +30,14 @@ module OnStrum
         end
       end
 
-      def complete?
-        !!(service_name && service_version)
-      end
-
       def formatter
         custom_formatter || builded_formatter
       end
 
-      # TODO: hardcoded fields will be removed in next release
       def log_attributes_order
-        @log_attributes_order ||= OnStrum::Logs::Configuration::SETTERS[3..6].map do |field_name_getter|
+        @log_attributes_order ||= OnStrum::Logs::Configuration::SETTERS[2..5].map do |field_name_getter|
           public_send(field_name_getter)
-        end + %i[service_name service_version]
+        end + root_fields.keys
       end
 
       private
@@ -52,6 +45,7 @@ module OnStrum
       def instance_initializer
         message_key = OnStrum::Logs::Configuration::BUILTIN_FIELDS_DEFAULT_NAMES[2]
         {
+          root_fields: {},
           field_name_level: OnStrum::Logs::Configuration::BUILTIN_FIELDS_DEFAULT_NAMES[0],
           field_name_time: OnStrum::Logs::Configuration::BUILTIN_FIELDS_DEFAULT_NAMES[1],
           field_name_message: message_key,
@@ -64,9 +58,9 @@ module OnStrum
       def valid_argument_type?(method_name, argument)
         argument.is_a?(
           case method_name
-          when :service_name, :service_version then ::String
-          when *OnStrum::Logs::Configuration::SETTERS[3..-1] then ::Symbol
+          when *OnStrum::Logs::Configuration::SETTERS[2..-1] then ::Symbol
           when :custom_formatter then ::Class
+          when :root_fields then ::Hash
           end
         )
       end

--- a/lib/on_strum/logs/logger/default.rb
+++ b/lib/on_strum/logs/logger/default.rb
@@ -39,8 +39,7 @@ module OnStrum
           @formatter ||= proc do |_severity, datetime, _progname, log_data|
             configuration.formatter.call(
               configuration.field_name_time => datetime,
-              service_name: configuration.service_name,
-              service_version: configuration.service_version,
+              **configuration.root_fields,
               **log_data
             )
           end

--- a/spec/on_strum/logs/formatter/detailed_spec.rb
+++ b/spec/on_strum/logs/formatter/detailed_spec.rb
@@ -14,13 +14,11 @@ RSpec.describe OnStrum::Logs::Formatter::Detailed do
     let(:time) { random_datetime }
     let(:message) { random_message }
     let(:context) { nil }
-    let(:service_name) { random_service_name }
-    let(:service_version) { random_semver }
+    let(:root_fields) { random_root_fields }
     let(:log_data) do
       [
         [field_name_level, level],
-        [:service_name, service_name],
-        [:service_version, service_version],
+        *root_fields.to_a,
         [field_name_time, time],
         [field_name_message, message],
         [field_name_context, context]
@@ -29,6 +27,7 @@ RSpec.describe OnStrum::Logs::Formatter::Detailed do
 
     before do
       init_configuration(
+        root_fields: root_fields,
         field_name_level: field_name_level,
         field_name_time: field_name_time,
         field_name_message: field_name_message,

--- a/spec/on_strum/logs/formatter/json_spec.rb
+++ b/spec/on_strum/logs/formatter/json_spec.rb
@@ -15,13 +15,11 @@ RSpec.describe OnStrum::Logs::Formatter::Json do
     let(:time_formatted) { time.strftime(described_class::DATETIME_FORMAT) }
     let(:message) { random_message }
     let(:context) { nil }
-    let(:service_name) { random_service_name }
-    let(:service_version) { random_semver }
+    let(:root_fields) { random_root_fields }
     let(:log_data) do
       [
         [field_name_level, level],
-        [:service_name, service_name],
-        [:service_version, service_version],
+        *root_fields.to_a,
         [field_name_time, time],
         [field_name_message, message],
         [field_name_context, context]
@@ -30,6 +28,7 @@ RSpec.describe OnStrum::Logs::Formatter::Json do
 
     before do
       init_configuration(
+        root_fields: root_fields,
         field_name_level: field_name_level,
         field_name_time: field_name_time,
         field_name_message: field_name_message,
@@ -49,8 +48,7 @@ RSpec.describe OnStrum::Logs::Formatter::Json do
             field_name_time => time_formatted,
             field_name_message => message,
             field_name_context => context,
-            service_name: service_name,
-            service_version: service_version
+            **root_fields
           }.to_json
         )
       )

--- a/spec/on_strum/logs/logger/default_spec.rb
+++ b/spec/on_strum/logs/logger/default_spec.rb
@@ -36,8 +36,7 @@ RSpec.describe OnStrum::Logs::Logger::Default do
               .with(
                 time: time,
                 level: method_name.to_s.upcase,
-                service_name: current_configuration.service_name,
-                service_version: current_configuration.service_version,
+                **current_configuration.root_fields,
                 **structured_log_data
               )
             logger

--- a/spec/on_strum/logs/rspec_helper/configuration_spec.rb
+++ b/spec/on_strum/logs/rspec_helper/configuration_spec.rb
@@ -17,21 +17,9 @@ RSpec.describe OnStrum::Logs::RspecHelper::Configuration, type: :helper do
   end
 
   describe '#create_configuration' do
-    subject(:configuration_builder) do
-      create_configuration(
-        service_name: service_name,
-        service_version: service_version
-      )
-    end
+    subject(:configuration_builder) { create_configuration }
 
-    let(:service_name) { random_service_name }
-    let(:service_version) { random_semver }
-
-    it 'returns configuration instance with defined params' do
-      expect(configuration_builder).to be_an_instance_of(OnStrum::Logs::Configuration)
-      expect(configuration_builder.service_name).to eq(service_name)
-      expect(configuration_builder.service_version).to eq(service_version)
-    end
+    it { is_expected.to be_an_instance_of(OnStrum::Logs::Configuration) }
   end
 
   describe '#init_configuration' do
@@ -47,8 +35,6 @@ RSpec.describe OnStrum::Logs::RspecHelper::Configuration, type: :helper do
 
     it 'initializes configuration instance with random and predefined params' do
       expect(configuration_initializer).to be_an_instance_of(OnStrum::Logs::Configuration)
-      expect(configuration_initializer.service_name).not_to be_nil
-      expect(configuration_initializer.service_version).not_to be_nil
       expect(configuration_initializer.custom_formatter).to eq(custom_formatter)
       expect(configuration_initializer.detailed_formatter).to eq(detailed_formatter)
     end

--- a/spec/on_strum/logs/rspec_helper/context_generator_spec.rb
+++ b/spec/on_strum/logs/rspec_helper/context_generator_spec.rb
@@ -24,9 +24,16 @@ RSpec.describe OnStrum::Logs::RspecHelper::ContextGenerator, type: :helper do
 
   describe '#random_field_name' do
     it 'returns random field name' do
-      random_field_name
       expect(::FFaker::Lorem).to receive(:word).and_call_original
       expect(random_field_name).to be_an_instance_of(::Symbol)
+    end
+  end
+
+  describe '#random_root_fields' do
+    it 'returns random root fields' do
+      expect(::FFaker::Lorem).to receive(:word).twice.and_call_original
+      expect(::FFaker::Lorem).to receive(:sentence).twice.and_call_original
+      expect(random_root_fields).to be_an_instance_of(::Hash)
     end
   end
 

--- a/spec/on_strum/logs_spec.rb
+++ b/spec/on_strum/logs_spec.rb
@@ -3,8 +3,7 @@
 RSpec.describe OnStrum::Logs do
   let(:custom_formatter) { use_formatter(:custom) }
   let(:detailed_formatter) { true }
-  let(:service_name) { random_service_name }
-  let(:service_version) { random_semver }
+  let(:root_fields) { random_root_fields }
   let(:field_name_level) { random_field_name }
   let(:field_name_time) { random_field_name }
   let(:field_name_message) { random_field_name }
@@ -28,8 +27,7 @@ RSpec.describe OnStrum::Logs do
           configuration_block(
             custom_formatter: custom_formatter,
             detailed_formatter: detailed_formatter,
-            service_name: service_name,
-            service_version: service_version,
+            root_fields: root_fields,
             field_name_level: field_name_level,
             field_name_time: field_name_time,
             field_name_message: field_name_message,
@@ -47,25 +45,13 @@ RSpec.describe OnStrum::Logs do
           expect(configuration).to be_an_instance_of(OnStrum::Logs::Configuration)
           expect(configuration.custom_formatter).to eq(custom_formatter)
           expect(configuration.detailed_formatter).to eq(detailed_formatter)
-          expect(configuration.service_name).to eq(service_name)
-          expect(configuration.service_version).to eq(service_version)
+          expect(configuration.root_fields).to eq(root_fields)
           expect(configuration.field_name_level).to eq(field_name_level)
           expect(configuration.field_name_time).to eq(field_name_time)
           expect(configuration.field_name_message).to eq(field_name_message)
           expect(configuration.field_name_context).to eq(field_name_context)
           expect(configuration.field_name_exception_message).to eq(field_name_exception_message)
           expect(configuration.field_name_exception_stack_trace).to eq(field_name_exception_stack_trace)
-        end
-      end
-
-      context 'when configuration is incomplete' do
-        let(:config_block) { configuration_block }
-
-        it 'raises configuration error' do
-          expect { configuration }.to raise_error(
-            OnStrum::Logs::Error::Configuration,
-            'service_name, service_version are required parameters'
-          )
         end
       end
     end
@@ -77,8 +63,7 @@ RSpec.describe OnStrum::Logs do
         &configuration_block(
           custom_formatter: custom_formatter,
           detailed_formatter: detailed_formatter,
-          service_name: service_name,
-          service_version: service_version,
+          root_fields: root_fields,
           field_name_level: field_name_level,
           field_name_time: field_name_time,
           field_name_message: field_name_message,
@@ -103,8 +88,7 @@ RSpec.describe OnStrum::Logs do
       described_class.configure(&configuration_block(
         custom_formatter: custom_formatter,
         detailed_formatter: detailed_formatter,
-        service_name: service_name,
-        service_version: service_version,
+        root_fields: root_fields,
         field_name_level: field_name_level,
         field_name_time: field_name_time,
         field_name_message: field_name_message,
@@ -118,8 +102,7 @@ RSpec.describe OnStrum::Logs do
       expect(configuration).to be_instance_of(OnStrum::Logs::Configuration)
       expect(configuration.custom_formatter).to eq(custom_formatter)
       expect(configuration.detailed_formatter).to eq(detailed_formatter)
-      expect(configuration.service_name).to eq(service_name)
-      expect(configuration.service_version).to eq(service_version)
+      expect(configuration.root_fields).to eq(root_fields)
       expect(configuration.field_name_level).to eq(field_name_level)
       expect(configuration.field_name_time).to eq(field_name_time)
       expect(configuration.field_name_message).to eq(field_name_message)

--- a/spec/support/helpers/configuration.rb
+++ b/spec/support/helpers/configuration.rb
@@ -17,13 +17,7 @@ module OnStrum
         end
 
         def init_configuration(**args)
-          OnStrum::Logs.configure(
-            &configuration_block(
-              service_name: random_service_name,
-              service_version: random_semver,
-              **args
-            )
-          )
+          OnStrum::Logs.configure(&configuration_block(**args))
         end
 
         def current_configuration

--- a/spec/support/helpers/context_generator.rb
+++ b/spec/support/helpers/context_generator.rb
@@ -20,6 +20,10 @@ module OnStrum
           FFaker::Lorem.word.to_sym
         end
 
+        def random_root_fields
+          ::Array.new(2) { [random_field_name, random_message] }.to_h
+        end
+
         def create_standard_error(message = random_message)
           ::StandardError.new(message)
         end

--- a/spec/support/schemas/stdout.json
+++ b/spec/support/schemas/stdout.json
@@ -8,9 +8,7 @@
       "level",
       "time",
       "message",
-      "context",
-      "service_name",
-      "service_version"
+      "context"
   ],
   "additionalProperties": false,
   "properties": {
@@ -46,22 +44,6 @@
           "examples": [{
               "attribute": "Tempore adipisci explicabo fugit laboriosam."
           }]
-      },
-      "service_name": {
-          "type": "string",
-          "default": "",
-          "title": "The service_name Schema",
-          "examples": [
-              "sachikosook_norberg"
-          ]
-      },
-      "service_version": {
-          "type": "string",
-          "default": "",
-          "title": "The service_version Schema",
-          "examples": [
-              "0.1.0"
-          ]
       }
   },
   "examples": [{


### PR DESCRIPTION
- [x] Implemented ability to define static fields in the logger document root
- [x] Updated `OnStrum::Logs::Configuration`, tests
- [x] Updated `OnStrum::Logs::Logger::Default`, test
- [x] Updated `OnStrum::Logs.configure`, tests
- [x] Updated RSpec helpers
- [x] Updated gem documentation